### PR TITLE
Add GitHub Actions workflow that check SQLite release

### DIFF
--- a/.github/scripts/check_and_update_sqlite.sh
+++ b/.github/scripts/check_and_update_sqlite.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+export SQLITEFTS5_PATH=$GITHUB_WORKSPACE/Formula/sqlitefts5.rb
+export SQLITE_TARBALL=$(curl -s https://sqlite.org/download.html | awk '/<!--/,/-->/ {print}' | grep 'sqlite-autoconf' | cut -d ',' -f 3)
+export SQLITE_TARBALL=https://sqlite.org/${SQLITE_TARBALL}
+curl -LsS -o sqlite.tar.gz ${SQLITE_TARBALL}
+export SHA256SUM=$(sha256sum sqlite.tar.gz | awk '{print $1}')
+export VERSION=$(curl -s https://sqlite.org/download.html | awk '/<!--/,/-->/ {print}' | grep 'sqlite-autoconf' | cut -d ',' -f 2)
+
+export CURRENT_VERSION=$(grep -o 'version "\S*"' ${SQLITEFTS5_PATH} | awk '{print $2}' | tr -d '"')
+if [ "$VERSION" = "$CURRENT_VERSION" ]; then
+    echo "No new version available"
+else
+    sed -i '0,/url "/s|url "\(.*\)"|url "'${SQLITE_TARBALL}'"|' ${SQLITEFTS5_PATH}
+    sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" ${SQLITEFTS5_PATH}
+    sed -i "s/sha256 \"[^\"]*\"/sha256 \"${SHA256SUM}\"/" ${SQLITEFTS5_PATH}
+    export IS_SQLITE_UPDATED=1
+fi
+

--- a/.github/workflows/check_and_update_sqlite.yml
+++ b/.github/workflows/check_and_update_sqlite.yml
@@ -1,0 +1,28 @@
+name: Check and Update SQLite
+
+on:
+  schedule:
+    - cron: '0 0 * * SUN' # every Sunday at midnight
+  workflow_dispatch:
+jobs:
+  check_and_update_sqlite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Grant execute permission for script
+        run: chmod +x .github/scripts/check_and_update_sqlite.sh
+      - name: Check Latest SQLite Version
+        id: check-latest-sqlite-version
+        run: |
+          source .github/scripts/check_and_update_sqlite.sh
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "LATEST_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "IS_SQLITE_UPDATED=$IS_SQLITE_UPDATED" >> $GITHUB_ENV
+      - name: Commit and Push
+        if: env.IS_SQLITE_UPDATED == 1
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/
+          git commit -m "Bump SQLite from ${{ env.CURRENT_VERSION }} to ${{ env.LATEST_VERSION }}"
+          git push origin master

--- a/.github/workflows/check_and_update_sqlite.yml
+++ b/.github/workflows/check_and_update_sqlite.yml
@@ -2,7 +2,7 @@ name: Check and Update SQLite
 
 on:
   schedule:
-    - cron: '0 0 * * SUN' # every Sunday at midnight
+    - cron: '0 0 * * *' # every day at midnight
   workflow_dispatch:
 jobs:
   check_and_update_sqlite:


### PR DESCRIPTION
This patch checks for the latest version of SQLite and patches the formula if SQLite has been updated.
This PR related to discussion [#3297](https://github.com/sqlitebrowser/sqlitebrowser/discussions/3297)

## Workflow work conditions
- Every Sunday at 00:00 UTC
- Manual
>Notes: 00:00 UTC is estimated to be a high load time for GitHub Actions workflow execution.
>As a result, it may run later than 00:00 [(Further information)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)

## Test results [(Fork)](https://github.com/lucydodo/homebrew-sqlite3)

### When the workflow confirm for a new release of SQLite
![Screenshot 2023-03-25 at 11 44 43](https://user-images.githubusercontent.com/64626662/227682786-823cd56d-05ca-4a27-a5fa-d72b4106dcfe.png)
**Action generates a commit for the new release of SQLite. (https://github.com/lucydodo/homebrew-sqlite3/commit/ea5b54cd9d1788814e28f841dc61ec8679dcbfb2 [/ Job)](https://github.com/lucydodo/homebrew-sqlite3/actions/runs/4517044388/jobs/7955949409)**

### When the workflow confirm for a no new release of SQLite

![Screenshot 2023-03-25 at 11 48 50](https://user-images.githubusercontent.com/64626662/227683756-2d040510-c2fb-46e5-a1da-2ffdb2b6ac93.png)
**We can see that the workflow skips the 'Commit and Push' job. [(Job)](https://github.com/lucydodo/homebrew-sqlite3/actions/runs/4517049877)**

## Required action before merge PR
In [Settings -> Actions](https://github.com/sqlitebrowser/homebrew-sqlite3/settings/actions), set the following:
- Code and automation -> Actions -> General
	- Actions permissions: `Allow all actions and reusable workflows`
	- Workflow permissions: `Read and write permissions`

Please feel free to review it. Thanks! 😄 